### PR TITLE
Added hack to replace '/' before contract name in sourceList

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -146,7 +146,14 @@ const convertMythXReport2EsIssue = (report, data) => {
         filePath: data.filePath,
     };
 
-    const sourceName = sourceList[sourceList.length - 1];
+    /**
+     * MythX API sends `sourceList` with `/` added in the contract name
+     * Example: sourceList: [ 'token.sol', '/token.sol' ]
+     *
+     * TODO: Remove the `replace` hack by fixing the `sourceList` response from MythX API
+     */
+
+    const sourceName = sourceList[sourceList.length - 1].replace(/^\//, '');
 
     result.messages = issues.map(issue => issue2EsLint(issue, data.sources[sourceName].source));
 


### PR DESCRIPTION
### Description
- [x] Added hack to replace '/' before contract name in sourceList returned from MythX API

Fixes: #34 