### PR TITLE
Send all related source code or AST to MythX API

### DIFF
--- a/sabre.js
+++ b/sabre.js
@@ -65,7 +65,7 @@ try {
 const input = {
     language: 'Solidity',
     sources: {
-        inputfile: {
+        [solidity_file_name]: {
             content: solidity_code
         }
     },
@@ -137,7 +137,7 @@ const getMythXReport = solidityCompiler => {
         process.exit(-1);
     }
 
-    let { inputfile } = compiled.contracts;
+    let inputfile = compiled.contracts[solidity_file_name];
     let contract, contractName;
 
     if (inputfile.length === 0) {
@@ -180,14 +180,18 @@ const getMythXReport = solidityCompiler => {
     };
 
     if (args.sendAST) {
-        data.sources[solidity_file_name] = { ast: compiled.sources.inputfile.ast };
+        for (const key in compiled.sources) {
+            data.sources[key] = { ast: compiled.sources[key].ast };
+        }
     } else {
-        data.sources[solidity_file_name] = { source: solidity_code };
+        for (const key in input.sources) {
+            data.sources[key] = { source: input.sources[key].content };
+        }
     }
 
     data.mainSource = solidity_file_name;
-    
-    if (args.debug){
+
+    if (args.debug) {
         console.log('-------------------');
         console.log('MythX Request Body:\n');
         console.log(util.inspect(data, false, null, true /* enable colors */));
@@ -213,7 +217,7 @@ const getMythXReport = solidityCompiler => {
             data.filePath = solidity_file_path;
 
             /* Add all the imported contracts source code to the `data` to sourcemap the issue location */
-            data.sources = { [solidity_file_name]: { content: solidity_code }, ...input.sources };
+            data.sources = { ...input.sources };
 
             if (args.debug){
                 console.log('-------------------');


### PR DESCRIPTION
In order to perform correct issue search and code analysis, all `import`-ed files have to be sent to the API. In other case there will be no possibility to track inheritance dependencies and other external code references. So I propose following changes to be merged. Thanks in advance.

## Status
Stable.

## Changes
- Added all imported files source code/AST (depending on `--sendAST`) to be send to MythX API.
- Switched from `inputfile` to use of `solidity_file_name` to allow `import`s AST to be more safer.

Regards, @blitz-1306.