### PR TITLE
Replace Armlet with MythXJS

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,8 @@
-const armlet = require('armlet');
+const mythx = require('mythxjs');
 const utils = require('./utils');
 
-const getRequestData = (input, compiledData, sourceList, solidity_file_name, mode) => {
+const getRequestData = (compiledData, sourceList, solidity_file_name, args) => {
     /* Format data for MythX API */
-
     const data = {
         contractName: compiledData.contractName,
         bytecode: utils.replaceLinkedLibs(compiledData.contract.evm.bytecode.object),
@@ -11,10 +10,11 @@ const getRequestData = (input, compiledData, sourceList, solidity_file_name, mod
         deployedBytecode: utils.replaceLinkedLibs(compiledData.contract.evm.deployedBytecode.object),
         deployedSourceMap: compiledData.contract.evm.deployedBytecode.sourceMap,
         sourceList,
-        analysisMode: mode,
+        analysisMode: args.mode,
+        toolName: args.clientToolName || 'sabre',
+        noCacheLookup: args.noCacheLookup,
         sources: {}
     };
-
 
     for (let key in compiledData.compiled.sources) {
         if (compiledData.compiled.sources.hasOwnProperty(key)) {
@@ -27,25 +27,76 @@ const getRequestData = (input, compiledData, sourceList, solidity_file_name, mod
     return data;
 };
 
-const getMythXReport = (args, ethAddress, password, data, initialDelay, timeout) => {
-    /* Instantiate MythX Client */
+const failAnalysis = (reason, status, uuid) => {
+    throw new Error(
+        reason + ' ' +
+        `The analysis job state is ${status.toLowerCase()} ` +
+        `and the result may become available later. UUID: ${uuid}.`
+    );
+};
 
-    const client = new armlet.Client(
-        {
-            ethAddress,
-            password,
+const watchMythXAnalysis = async (client, analysis, initialDelay, timeout) => {
+    const statuses = [ 'Error', 'Finished' ];
+
+    let state = await client.getAnalysisStatus(analysis.uuid);
+
+    if (statuses.includes(state.status)) {
+        return state;
+    }
+
+    const timer = interval => new Promise(resolve => setTimeout(resolve, interval));
+
+    const maxRequests = 10;
+    const start = Date.now();
+    const remaining = Math.max(timeout - initialDelay, 0);
+    const inverted = Math.sqrt(remaining) / Math.sqrt(285);
+
+    for (let r = 0; r < maxRequests; r++) {
+        const idle = Math.min(
+            r === 0 ? initialDelay : (inverted * r) ** 2,
+            start + timeout - Date.now()
+        );
+
+        await timer(idle);
+
+        if (Date.now() - start >= timeout) {
+            failAnalysis(
+                `User or default timeout reached after ${timeout / 1000} sec(s).`,
+                state.status,
+                analysis.uuid
+            );
         }
-    );
 
-    return client.analyzeWithStatus({
-        data,
-        analysisMode: args.mode,
-        clientToolName: args.clientToolName || 'sabre',
-        noCacheLookup: args.noCacheLookup,
-    },
-    timeout,
-    initialDelay
+        state = await client.getAnalysisStatus(analysis.uuid);
+
+        if (statuses.includes(state.status)) {
+            return state;
+        }
+    }
+
+    failAnalysis(
+        `Allowed number (${maxRequests}) of requests was reached.`,
+        state.status,
+        analysis.uuid
     );
+};
+
+const getMythXReport = async (ethAddress, password, data, initialDelay, timeout) => {
+    /* Instantiate MythX Client */
+    const client = new mythx.Client(ethAddress, password);
+
+    await client.login();
+
+    const analysis = await client.analyze(data);
+
+    await watchMythXAnalysis(client, analysis, initialDelay, timeout);
+
+    const issues = await client.getDetectedIssues(analysis.uuid);
+
+    return {
+        uuid: analysis.uuid,
+        issues
+    };
 };
 
 module.exports = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -81,9 +81,9 @@ const watchMythXAnalysis = async (client, analysis, initialDelay, timeout) => {
     );
 };
 
-const getMythXReport = async (ethAddress, password, data, initialDelay, timeout) => {
+const getMythXReport = async (apiUrl, ethAddress, password, data, initialDelay, timeout) => {
     /* Instantiate MythX Client */
-    const client = new mythx.Client(ethAddress, password);
+    const client = new mythx.Client(ethAddress, password, undefined, apiUrl);
 
     await client.login();
 

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "author": "Bernhard Mueller",
   "license": "MIT",
   "dependencies": {
-    "armlet": "^2.6.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",
     "minimist": "^1.2.0",
+    "mythxjs": "^1.3.1",
     "openzeppelin-solidity": "^2.2.0",
     "ora": "^3.4.0",
     "package.json": "^2.0.1",

--- a/sabre.js
+++ b/sabre.js
@@ -19,7 +19,7 @@ let password = process.env.MYTHX_PASSWORD;
 let apiUrl = process.env.MYTHX_API_URL;
 
 const args = require('minimist')(process.argv.slice(2), {
-    boolean: [ 'version', 'help', 'apiVersion', 'noCacheLookup', 'debug' ],
+    boolean: [ 'version', 'help', 'noCacheLookup', 'debug' ],
     string: [ 'mode', 'format' ],
     default: { mode: 'quick', format: 'stylish' },
 });

--- a/sabre.js
+++ b/sabre.js
@@ -19,7 +19,7 @@ let password = process.env.MYTHX_PASSWORD;
 let apiUrl = process.env.MYTHX_API_URL;
 
 const args = require('minimist')(process.argv.slice(2), {
-    boolean: [ 'noCacheLookup', 'debug'],
+    boolean: [ 'version', 'help', 'apiVersion', 'noCacheLookup', 'debug' ],
     string: [ 'mode', 'format' ],
     default: { mode: 'quick', format: 'stylish' },
 });
@@ -31,6 +31,8 @@ USAGE:
 $ sabre [options] <solidity_file> [contract_name]
 
 OPTIONS:
+    --version                                       Print version
+    --help                                          Print help message
     --mode <quick/full>                             Analysis mode (default=quick)
     --format <stylish/compact/table/html/json>      Output format (default=stylish)
     --clientToolName <string>                       Override clientToolName
@@ -38,10 +40,18 @@ OPTIONS:
     --debug                                         Print MythX API request and response
 `;
 
-if (!args._.length) {
+if (args.version) {
+    const { version } = require('./package.json');
+
+    console.log(version);
+
+    process.exit(0);
+}
+
+if (!args._.length || args.help) {
     console.log(helpText);
 
-    process.exit(-1);
+    process.exit(0);
 }
 
 if (!['quick', 'full'].includes(args.mode)) {

--- a/sabre.js
+++ b/sabre.js
@@ -16,6 +16,7 @@ const util = require('util');
 
 let ethAddress = process.env.MYTHX_ETH_ADDRESS;
 let password = process.env.MYTHX_PASSWORD;
+let apiUrl = process.env.MYTHX_API_URL;
 
 const args = require('minimist')(process.argv.slice(2), {
     boolean: [ 'noCacheLookup', 'debug'],
@@ -142,7 +143,7 @@ try {
 
                 const analysisSpinner = ora({ text: 'Analyzing ' + compiledData.contractName, color: 'yellow', spinner: 'bouncingBar' }).start();
 
-                client.getMythXReport(ethAddress, password, data, initialDelay, timeout)
+                client.getMythXReport(apiUrl, ethAddress, password, data, initialDelay, timeout)
                     .then(result => {
                         /* Stop the spinner and clear from the terminal */
                         analysisSpinner.stop();


### PR DESCRIPTION
## Tasks
- resolves #69 

## Status
**Stable**. Review will be appreciated.

## Changes
- Removed [**Armlet**](https://github.com/ConsenSys/armlet/) dependency.
- Added [**MythXJS**](https://github.com/ConsenSys/mythxjs/) dependency.
- Overhauled **lib/client.js** to use MythXJS instead of Armlet:
    - `getRequestData()` now completely controls analysis data arranging process (that was partial due to Armlet's older interface).
    - `getMythXReport()` is `async` now because must control a lot of asynchronous remote actions, provided by MythXJS.
- Minor fixes in **sabre.js**:
    - Implemented `--version` CLI option/switch.
    - Implemented `--help` CLI option/switch.
    - Added v-spaces between some constructs for clarity.
    - Switched arguments for `getRequestData()` and `getMythXReport()`.
    - Renamed `mythxSpinner` to `analysisSpinner`.
    - Other minor stuff.

## Notes
- No error handling to refresh JWT tokens yet. It is a question if this logic is needed in case of short-term analyses.
- MythxJS is not yet supporting `--noCacheLookup` parameter, so it will need additional fix. I've created a PR for it: https://github.com/ConsenSys/mythxjs/pull/24. When it will be merged, we will need to recheck current behavior.
- Polling mechanic is borrowed from Armlet and optimized little bit.
- This PR is heavily relying on `async` / `await`.

Regards, @blitz-1306.