### PR TITLE
Made issue titles to contain SWC-title instead of fixed text

### DIFF
--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -1,6 +1,5 @@
-const header = '==== Exception State ====';
-const separator = '-'.repeat(header.length);
 const textFormatter = {};
+const separator = '-'.repeat(20);
 
 textFormatter.strToInt = str => parseInt(str, 10);
 
@@ -20,9 +19,10 @@ textFormatter.formatLocation = message => {
 textFormatter.formatMessage = (message, filePath) => {
     const mythxIssue = message.mythx;
     const source = message.source;
-    const output = [header];
+    const output = [];
 
     output.push(
+        `==== ${mythxIssue.swcTitle} ====`,
         'Severity: ' + mythxIssue.severity,
         'File: ' + filePath
     );


### PR DESCRIPTION
## Tasks
- resolves #79 

## Status
**Stable**.

## Changes
- Text output formatter not will contain SWC-title instead of fixed text `Exception State`. https://github.com/b-mueller/sabre/blob/0d1fa9d82a28644f6a62887b58180f2513dc5346/lib/formatters/text.js#L25
- Text output formatter issue section separators will be contains 20 hyphen (`-`) characters. https://github.com/b-mueller/sabre/blob/0d1fa9d82a28644f6a62887b58180f2513dc5346/lib/formatters/text.js#L2

Regards, @blitz-1306.