### PR TITLE
Display analysis UUID

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 const mythx = require('mythxjs');
 const utils = require('./utils');
 
-const getRequestData = (compiledData, sourceList, solidity_file_name, args) => {
+const getRequestData = (compiledData, sourceList, fileName, args) => {
     /* Format data for MythX API */
     const data = {
         contractName: compiledData.contractName,
@@ -22,23 +22,25 @@ const getRequestData = (compiledData, sourceList, solidity_file_name, args) => {
         }
     }
 
-    data.mainSource = solidity_file_name;
+    data.mainSource = fileName;
 
     return data;
 };
 
 const failAnalysis = (reason, status, uuid) => {
     throw new Error(
-        reason + ' ' +
-        `The analysis job state is ${status.toLowerCase()} ` +
-        `and the result may become available later. UUID: ${uuid}.`
+        reason +
+        ' ' +
+        'The analysis job state is ' +
+        status.toLowerCase() +
+        ' and the result may become available later.'
     );
 };
 
-const watchMythXAnalysis = async (client, analysis, initialDelay, timeout) => {
+const awaitAnalysisFinish = async (client, uuid, initialDelay, timeout) => {
     const statuses = [ 'Error', 'Finished' ];
 
-    let state = await client.getAnalysisStatus(analysis.uuid);
+    let state = await client.getAnalysisStatus(uuid);
 
     if (statuses.includes(state.status)) {
         return state;
@@ -63,11 +65,11 @@ const watchMythXAnalysis = async (client, analysis, initialDelay, timeout) => {
             failAnalysis(
                 `User or default timeout reached after ${timeout / 1000} sec(s).`,
                 state.status,
-                analysis.uuid
+                uuid
             );
         }
 
-        state = await client.getAnalysisStatus(analysis.uuid);
+        state = await client.getAnalysisStatus(uuid);
 
         if (statuses.includes(state.status)) {
             return state;
@@ -77,37 +79,36 @@ const watchMythXAnalysis = async (client, analysis, initialDelay, timeout) => {
     failAnalysis(
         `Allowed number (${maxRequests}) of requests was reached.`,
         state.status,
-        analysis.uuid
+        uuid
     );
 };
 
-const getMythXReport = async (apiUrl, ethAddress, password, data, initialDelay, timeout) => {
-    /* Instantiate MythX Client */
-    const client = new mythx.Client(ethAddress, password, undefined, apiUrl);
+const initialize = (apiUrl, ethAddress, password) => {
+    return new mythx.Client(ethAddress, password, undefined, apiUrl);
+}
 
-    await client.login();
-
-    const analysis = await client.analyze(data);
-
-    await watchMythXAnalysis(client, analysis, initialDelay, timeout);
-
-    const issues = await client.getDetectedIssues(analysis.uuid);
-
-    return {
-        uuid: analysis.uuid,
-        issues
-    };
+const authenticate = async (client) => {
+    return await client.login();
 };
 
-const getMythXApiVersion = async (apiUrl, ethAddress, password) => {
-    const client = new mythx.Client(ethAddress, password, undefined, apiUrl);
-    const data = await client.getVersion();
+const submitDataForAnalysis = async(client, data) => {
+    return await client.analyze(data);
+};
 
-    return data;
+const getReport = async (client, uuid) => {
+    return await client.getDetectedIssues(uuid);
+};
+
+const getApiVersion = async (client) => {
+    return await client.getVersion();
 };
 
 module.exports = {
-    getMythXApiVersion,
-    getMythXReport,
+    initialize,
+    authenticate,
+    awaitAnalysisFinish,
+    submitDataForAnalysis,
+    getApiVersion,
+    getReport,
     getRequestData
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,7 +27,7 @@ const getRequestData = (compiledData, sourceList, fileName, args) => {
     return data;
 };
 
-const failAnalysis = (reason, status, uuid) => {
+const failAnalysis = (reason, status) => {
     throw new Error(
         reason +
         ' ' +
@@ -64,8 +64,7 @@ const awaitAnalysisFinish = async (client, uuid, initialDelay, timeout) => {
         if (Date.now() - start >= timeout) {
             failAnalysis(
                 `User or default timeout reached after ${timeout / 1000} sec(s).`,
-                state.status,
-                uuid
+                state.status
             );
         }
 
@@ -78,14 +77,13 @@ const awaitAnalysisFinish = async (client, uuid, initialDelay, timeout) => {
 
     failAnalysis(
         `Allowed number (${maxRequests}) of requests was reached.`,
-        state.status,
-        uuid
+        state.status
     );
 };
 
 const initialize = (apiUrl, ethAddress, password) => {
     return new mythx.Client(ethAddress, password, undefined, apiUrl);
-}
+};
 
 const authenticate = async (client) => {
     return await client.login();

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,7 +1,9 @@
 const chalk = require('chalk');
 const fs = require('fs');
-const https = require('https');
+const axios = require('axios');
 const path = require('path');
+const requireFromString = require('require-from-string');
+const solc = require('solc');
 const parser = require('solidity-parser-antlr');
 const releases = require('./releases');
 
@@ -40,42 +42,62 @@ const getImportPaths = source => {
     return matches;
 };
 
-/* Get solc-js of specific version from temp directory, if exists */
+/**
+ * 
+ * @param {string} version Solc version string
+ * 
+ * @returns {Promise<solc>} Loaded Solc version snapshot object
+ */
+const loadSolcVersion = async version => {
+    const tempDir = path.join(path.dirname(require.main.filename), '.temp');
+    const filePath = path.join(tempDir, version + '.js');
 
-const loadSolcVersion = (version, callback) => {
-    const tempDir = path.dirname(require.main.filename) + '/.temp/';
-    const solcPath =  tempDir + version + '.js';
+    const fromCache = fs.existsSync(filePath);
 
-    if (fs.existsSync(solcPath)) {
-        callback(fs.readFileSync(solcPath).toString());
+    let solcString;
+
+    if (fromCache) {
+        solcString = fs.readFileSync(filePath).toString();
     } else {
-        /* Create `.temp` directory if it doesn't exist */
+        const config = {
+            method: 'get',
+            url: 'https://ethereum.github.io/solc-bin/bin/soljson-' + version + '.js',
+            responseType: 'stream'
+        };
 
-        if (!fs.existsSync(tempDir)) {
-            fs.mkdirSync(tempDir);
-        }
+        solcString = await axios(config).then(response => {
+            /**
+             * Create `.temp` directory if it doesn't exist
+             */
+            if (!fs.existsSync(tempDir)) {
+                fs.mkdirSync(tempDir);
+            }
 
-        /* Get the solc remote version snapshot of the specified version */
+            const stream = fs.createWriteStream(filePath);
 
-        const solcJs = fs.createWriteStream(solcPath);
-        const url = 'https://ethereum.github.io/solc-bin/bin/soljson-' + version + '.js';
+            response.data.pipe(stream);
 
-        https
-            .get(url, (response) => {
-                if (response.statusCode !== 200) {
-                    throw new Error('Error retrieving binary: ' + response.statusMessage);
-                } else {
-                    const stream = response.pipe(solcJs);
-
-                    stream.on('finish', () => {
-                        callback(fs.readFileSync(solcPath).toString());
-                    });
-                }
-            })
-            .on('error',  (error) => {
-                throw new Error('Error fetching binary: ' + error);
+            return new Promise((resolve, reject) => {
+                stream.on(
+                    'finish',
+                    () => resolve(fs.readFileSync(filePath).toString())
+                ).on(
+                    'error',
+                    err => reject(err)
+                );
             });
+        });
     }
+
+    /**
+     * NOTE: `solcSnapshot` has the same interface as the `solc`.
+     */
+    const solcSnapshot = solc.setupMethods(
+        requireFromString(solcString),
+        'soljson-' + releases[version] + '.js'
+    );
+
+    return { solcSnapshot, fromCache };
 };
 
 /* Get solidity version specified in the contract */

--- a/lib/controllers/analyze.js
+++ b/lib/controllers/analyze.js
@@ -1,10 +1,8 @@
-const solc = require('solc');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const chalk = require('chalk');
 const ora = require('ora');
-const requireFromString = require('require-from-string');
 const Profiler = require('truffle-compile/profiler');
 const Resolver = require('truffle-resolver');
 const client = require('../client');
@@ -15,14 +13,18 @@ const releases = require('../releases');
 module.exports = async (env, args) => {
     let { ethAddress, password, apiUrl } = env;
 
-    if (!['quick', 'full'].includes(args.mode)) {
-        console.log('Invalid analysis mode. Please use either "quick" or "full".');
+    const modes = ['quick', 'full'];
+
+    if (!modes.includes(args.mode)) {
+        console.log('Invalid analysis mode. Available modes: ' + modes.join(', ') + '.');
 
         process.exit(-1);
     }
 
-    if (['stylish', 'compact', 'table', 'html', 'json', 'text'].indexOf(args.format) < 0) {
-        console.log('Invalid output format. Please use "stylish", "compact", "table", "html" or "json".');
+    const formats = ['text', 'stylish', 'compact', 'table', 'html', 'json'];
+
+    if (!formats.includes(args.format)) {
+        console.log('Invalid output format. Available formats: ' + formats.join(', ') + '.');
 
         process.exit(-1);
     }
@@ -35,131 +37,165 @@ module.exports = async (env, args) => {
         password = 'trial';
     }
 
-    let solidityCode;
-
-    try {
-        solidityCode = fs.readFileSync(solidityFilePath, 'utf8');
-    } catch (err) {
-        console.log('Error opening input file ' + err.message);
-
-        process.exit(-1);
-    }
-
     const resolver = new Resolver({
         working_directory: solidityFileDir,
         contracts_build_directory: solidityFileDir
     });
 
-    const allSources = {};
-
-    /* Get the version of the Solidity Compiler */
-
-    const version = compiler.getSolidityVersion(solidityCode);
-
-    const compileSpinner = ora({ text: `Downloading solc v${version}`, color: 'yellow', spinner: 'bouncingBar' }).start();
+    const spinner = ora({
+        color: 'yellow',
+        spinner: 'bouncingBar'
+    });
 
     try {
-        compiler.loadSolcVersion(releases[version], (solcString) => {
-            /* NOTE: `solcSnapshot` has the same interface as `solc` */
-            const solcSnapshot = solc.setupMethods(
-                requireFromString(solcString),
-                'soljson-' + releases[version] + '.js'
-            );
+        spinner.start('Reading input file');
 
-            let compiledData;
+        const solidityCode = fs.readFileSync(solidityFilePath, 'utf8');
 
-            /* Parse all the import sources and the `sourceList` */
-            Profiler.resolveAllSources(resolver, [solidityFilePath], solcSnapshot)
-                .then(resolved => {
-                    const sourceList = Object.keys(resolved);
+        spinner.stop();
 
-                    sourceList.forEach(file => {
-                        allSources[file] = { content: resolved[file].body };
-                    });
+        spinner.start('Detecting solidity version');
 
-                    /* Get the input config for the Solidity Compiler */
-                    const input = compiler.getSolcInput(allSources);
+        /* Get the version of the Solidity Compiler */
+        const version = compiler.getSolidityVersion(solidityCode);
 
-                    try {
-                        compiledData = compiler.getCompiledContracts(input, solcSnapshot, solidityFilePath, args._[1]);
-                    } catch (e) {
-                        console.log(chalk.red(e.message));
+        spinner.stop();
 
-                        process.exit(1);
-                    }
+        spinner.start(`Loading solc v${version}`);
 
-                    compileSpinner.succeed(`Compiled with solc v${version} successfully`);
+        const { solcSnapshot, fromCache } = await compiler.loadSolcVersion(
+            releases[version]
+        );
 
-                    const data = client.getRequestData(
-                        compiledData,
-                        sourceList,
-                        solidityFilePath,
-                        args
-                    );
+        spinner.succeed(
+            fromCache
+                ? `Loaded solc v${version} from local cache`
+                : `Downloaded solc v${version} and saved to local cache`
+        );
 
-                    let initialDelay;
-                    let timeout;
+        spinner.start('Resolving imports');
 
-                    if (args.mode == 'quick') {
-                        initialDelay = 20 * 1000;
-                        timeout = 180 * 1000;
-                    } else {
-                        initialDelay = 300 * 1000;
-                        timeout = 2400 * 1000;
-                    }
+        /* Parse all the import sources and the `sourceList` */
+        const resolvedSources = await Profiler.resolveAllSources(
+            resolver,
+            [solidityFilePath],
+            solcSnapshot
+        );
 
-                    if (args.debug) {
-                        console.log('-------------------');
-                        console.log('MythX Request Body:\n');
-                        console.log(util.inspect(data, false, null, true /* enable colors */));
-                    }
+        const sourceList = Object.keys(resolvedSources);
 
-                    const analysisSpinner = ora({ text: 'Analyzing ' + compiledData.contractName, color: 'yellow', spinner: 'bouncingBar' }).start();
+        spinner.stop();
 
-                    client.getMythXReport(apiUrl, ethAddress, password, data, initialDelay, timeout)
-                        .then(result => {
-                            /* Stop the spinner and clear from the terminal */
-                            analysisSpinner.stop();
+        spinner.start(
+            sourceList.length === 1 ? 'Compiling source' : 'Compiling sources'
+        );
 
-                            /* Add all the imported contracts source code to the `data` to sourcemap the issue location */
-                            data.sources = { ...input.sources };
+        const allSources = {};
 
-                            /* Copy reference to compiled function hashes */
-                            data.functionHashes = compiledData.functionHashes;
-
-                            if (args.debug) {
-                                console.log('-------------------');
-                                console.log('MythX Response Body:\n');
-                                console.log(util.inspect(result, { showHidden: false, depth: null }));
-                                console.log('-------------------');
-                            }
-
-                            const { issues } = result;
-                            const uniqueIssues = report.formatIssues(data, issues);
-
-                            if (uniqueIssues.length === 0) {
-                                console.log(chalk.green(`✔ No errors/warnings found in ${args._[0]} for contract: ${compiledData.contractName}`));
-                            } else {
-                                const formatter = report.getFormatter(args.format);
-
-                                console.log(formatter(uniqueIssues));
-                            }
-                        })
-                        .catch(err => {
-                            analysisSpinner.fail('Analysis failed');
-
-                            console.log(chalk.red(err));
-                        });
-                })
-                .catch(err => {
-                    compileSpinner.fail('Resolving imports failed');
-
-                    console.log(chalk.red(err));
-                });
+        sourceList.forEach(file => {
+            allSources[file] = { content: resolvedSources[file].body };
         });
+
+        /* Get the input config for the Solidity Compiler */
+        const input = compiler.getSolcInput(allSources);
+
+        const compiledData = compiler.getCompiledContracts(
+            input,
+            solcSnapshot,
+            solidityFilePath,
+            args._[1]
+        );
+
+        spinner.succeed(`Compiled with solc v${version} successfully`);
+
+        spinner.start('Authenticating user');
+
+        const mxClient = client.initialize(apiUrl, ethAddress, password);
+
+        await client.authenticate(mxClient);
+
+        spinner.stop();
+
+        spinner.start('Submitting data for analysis');
+
+        const data = client.getRequestData(
+            compiledData,
+            sourceList,
+            solidityFilePath,
+            args
+        );
+
+        if (args.debug) {
+            console.log('-------------------');
+            console.log('MythX Request Body:\n');
+            console.log(util.inspect(data, false, null, true));
+        }
+
+        const { uuid } = await client.submitDataForAnalysis(mxClient, data);
+
+        spinner.succeed(
+            'Analysis job with UUID ' +
+            chalk.yellow(uuid) +
+            ' is now in progress'
+        );
+
+        spinner.start('Analyzing ' + compiledData.contractName);
+
+        let initialDelay;
+        let timeout;
+
+        if (args.mode === 'quick') {
+            initialDelay = 20 * 1000;
+            timeout = 180 * 1000;
+        } else {
+            initialDelay = 300 * 1000;
+            timeout = 2400 * 1000;
+        }
+
+        await client.awaitAnalysisFinish(
+            mxClient,
+            uuid,
+            initialDelay,
+            timeout
+        );
+
+        spinner.stop();
+
+        spinner.start('Retrieving analysis results');
+
+        const issues = await client.getReport(mxClient, uuid);
+
+        spinner.stop();
+
+        /* Add all the imported contracts source code to the `data` to sourcemap the issue location */
+        data.sources = { ...input.sources };
+
+        /* Copy reference to compiled function hashes */
+        data.functionHashes = compiledData.functionHashes;
+
+        if (args.debug) {
+            console.log('-------------------');
+            console.log('MythX Response Body:\n');
+            console.log(util.inspect(issues, { showHidden: false, depth: null }));
+            console.log('-------------------');
+        }
+
+        const uniqueIssues = report.formatIssues(data, issues);
+
+        if (uniqueIssues.length === 0) {
+            console.log(chalk.green(`✔ No errors/warnings found in ${args._[0]} for contract: ${compiledData.contractName}`));
+        } else {
+            const formatter = report.getFormatter(args.format);
+
+            console.log(formatter(uniqueIssues));
+        }
     } catch (err) {
-        compileSpinner.fail(`Compilation with solc v${version} failed`);
+        if (spinner.isSpinning) {
+            spinner.fail();
+        }
 
         console.log(chalk.red(err));
+
+        process.exit(1);
     }
 };

--- a/lib/controllers/api_version.js
+++ b/lib/controllers/api_version.js
@@ -13,11 +13,13 @@ module.exports = async (env, args) => {
     const spinner = ora(spinnerConfig).start();
 
     try {
-        const data = await client.getMythXApiVersion(
+        const mxClient = client.initialize(
             env.apiUrl,
             env.ethAddress,
             env.password
         );
+
+        const data = await client.getApiVersion(mxClient);
 
         spinner.stop();
 

--- a/lib/formatters/text.js
+++ b/lib/formatters/text.js
@@ -108,7 +108,7 @@ textFormatter.formatMessage = (message, filePath, sourceCode, fnHashes) => {
     const output = [];
 
     output.push(
-        `==== ${mythxIssue.swcTitle} ====`,
+        `==== ${mythxIssue.swcTitle || 'N/A'} ====`,
         'Severity: ' + mythxIssue.severity,
         'File: ' + filePath
     );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Bernhard Mueller",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.19.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
## Tasks
- resolves #86 

## Status
**Stable**.

## Changes
- Added **axios** ([npm](https://www.npmjs.com/package/axios), [GitHub](https://github.com/axios/axios)) as dependency to "promisify" `compiler.loadSolcVersion()` properly.
- Refactored **lib/client.js** as we now need different data, depending on API interactions. Mage interactions more granular.
- Refactored **lib/controllers/analyze.js**:
    - Now execution flow is largely flattened, also there is no more Promise and callback hells
    - Now we have only one spinner there instead of 3 diffrent spinners.
    - Added more spinnter messages to indicate execution stages more clearly. When error is encountered, current spinner message will be preserved, so we can narrow code segment, where error was triggered. Also, crucial execution stages will be preserved at screen:
        - Compiler loading (or downloading).
        - Compile status.
        - Analysis submission (including UUID).
- Refactored **lib/controllers/api-version.js** to follow changes in **lib/client.js**.
- Now text issue formatter will display `N/A` for issue titles, when API response contains issue with empty field.

Regards, @blitz-1306.