### PR TITLE
Fix report rendering to properly display issues without references to a particular file

### DIFF
--- a/lib/controllers/analyze.js
+++ b/lib/controllers/analyze.js
@@ -126,9 +126,13 @@ module.exports = async (env, args) => {
         );
 
         if (args.debug) {
+            spinner.stop();
+
             console.log('-------------------');
             console.log('MythX Request Body:\n');
             console.log(util.inspect(data, false, null, true));
+
+            spinner.start();
         }
 
         const { uuid } = await client.submitDataForAnalysis(mxClient, data);
@@ -167,6 +171,8 @@ module.exports = async (env, args) => {
 
         spinner.stop();
 
+        spinner.start('Rendering output');
+
         /* Add all the imported contracts source code to the `data` to sourcemap the issue location */
         data.sources = { ...input.sources };
 
@@ -174,20 +180,29 @@ module.exports = async (env, args) => {
         data.functionHashes = compiledData.functionHashes;
 
         if (args.debug) {
+            spinner.stop();
+
             console.log('-------------------');
             console.log('MythX Response Body:\n');
-            console.log(util.inspect(issues, { showHidden: false, depth: null }));
+            console.log(util.inspect(issues, false, null, true));
             console.log('-------------------');
+
+            spinner.start();
         }
 
         const uniqueIssues = report.formatIssues(data, issues);
 
         if (uniqueIssues.length === 0) {
+            spinner.stop();
+
             console.log(chalk.green(`✔ No errors/warnings found in ${args._[0]} for contract: ${compiledData.contractName}`));
         } else {
             const formatter = report.getFormatter(args.format);
+            const output = formatter(uniqueIssues);
 
-            console.log(formatter(uniqueIssues));
+            spinner.stop();
+
+            console.log(output);
         }
     } catch (err) {
         if (spinner.isSpinning) {

--- a/lib/report.js
+++ b/lib/report.js
@@ -75,17 +75,17 @@ const textSrcEntry2lineColumn = (srcEntry, lineBreakPositions) => {
  *
  * @param {object} issue - the MythX issue we want to convert
  * @param {string} sourceCode - holds the contract code
- * @param {object[]} textLocations - array of text-only MythX API issue locations
+ * @param {object[]} locations - array of text-only MythX API issue locations
  * @returns eslint -issue object
  */
-const issue2EsLint = (issue, sourceCode, textLocations) => {
+const issue2EsLint = (issue, sourceCode, locations) => {
     const swcLink = issue.swcID
         ? 'https://smartcontractsecurity.github.io/SWC-registry/docs/' + issue.swcID
         : 'N/A';
 
     const esIssue = {
         mythxIssue: issue,
-        mythxTextLocations: textLocations,
+        mythxTextLocations: locations,
         sourceCode: sourceCode,
 
         fatal: false,
@@ -98,13 +98,13 @@ const issue2EsLint = (issue, sourceCode, textLocations) => {
         endCol: 0
     };
 
-    let startLineCol,  endLineCol;
+    let startLineCol, endLineCol;
 
     const lineBreakPositions = decoder.getLinebreakPositions(sourceCode);
 
-    if (textLocations.length) {
+    if (locations.length) {
         [startLineCol, endLineCol] = textSrcEntry2lineColumn(
-            textLocations[0].sourceMap,
+            locations[0].sourceMap,
             lineBreakPositions
         );
     }
@@ -123,18 +123,14 @@ const issue2EsLint = (issue, sourceCode, textLocations) => {
 /**
  * Gets the source index from the issue sourcemap
  * 
- * @param {object[]} locations - array of text-only MythX API issue locations
+ * @param {object} location - MythX API issue location object
  * @returns {number}
  */
-const getSourceIndex = locations => {
-    if (locations.length) {
-        const sourceMapRegex = /(\d+):(\d+):(\d+)/g;
-        const match = sourceMapRegex.exec(locations[0].sourceMap);
-        // Ignore `-1` source index for compiler generated code
-        return match ? match[3] : 0;
-    }
-
-    return 0;
+const getSourceIndex = location => {
+    const sourceMapRegex = /(\d+):(\d+):(\d+)/g;
+    const match = sourceMapRegex.exec(location.sourceMap);
+    // Ignore `-1` source index for compiler generated code
+    return match ? match[3] : 0;
 };
 
 /**
@@ -144,7 +140,6 @@ const getSourceIndex = locations => {
  * @returns {object}
  */
 const convertMythXReport2EsIssue = (report, data) => {
-    const { issues, sourceList } = report;
     const { sources, functionHashes } = data;
     const results = {};
 
@@ -152,7 +147,7 @@ const convertMythXReport2EsIssue = (report, data) => {
      * Filters locations only for source files.
      * Other location types are not supported to detect code.
      * 
-     * @param {object} location 
+     * @param {object} location
      */
     const textLocationFilterFn = location => (
         (location.sourceType === 'solidity-file')
@@ -160,37 +155,51 @@ const convertMythXReport2EsIssue = (report, data) => {
         (location.sourceFormat === 'text')
     );
 
-    issues.forEach(issue => {
-        const textLocations = issue.locations.filter(textLocationFilterFn);
-        const sourceIndex = getSourceIndex(textLocations);
-        const filePath = sourceList[sourceIndex];
-        const sourceCode = sources[filePath].content;
+    report.issues.forEach(issue => {
+        const locations = issue.locations.filter(textLocationFilterFn);
+        const location = locations.length ? locations[0] : undefined;
 
-        if (!results[filePath]) {
-            results[filePath] = {
+        let sourceCode = '';
+        let sourcePath = '<unknown>';
+
+        if (location) {
+            const sourceList = location.sourceList || report.sourceList || [];
+            const sourceIndex = getSourceIndex(location);
+            const fileName = sourceList[sourceIndex];
+
+            if (fileName && sources[fileName]) {
+                sourcePath = fileName;
+                sourceCode = sources[fileName].content;
+            }
+        }
+
+        if (!results[sourcePath]) {
+            results[sourcePath] = {
                 errorCount: 0,
                 warningCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
-                filePath,
+                filePath: sourcePath,
                 functionHashes,
                 sourceCode,
                 messages: [],
             };
         }
 
-        results[filePath].messages.push(
-            issue2EsLint(issue, sourceCode, textLocations)
+        results[sourcePath].messages.push(
+            issue2EsLint(issue, sourceCode, locations)
         );
     });
 
-    for (let k in results) {
-        if (results.hasOwnProperty(k)) {
-            results[k].warningCount = results[k].messages.reduce((acc,  { fatal, severity }) =>
-                !eslintHelpers.isFatal(fatal , severity) ? acc + 1: acc, 0);
+    for (const key in results) {
+        const result = results[key];
 
-            results[k].errorCount = results[k].messages.reduce((acc,  { fatal, severity }) =>
-                eslintHelpers.isFatal(fatal , severity) ? acc + 1: acc, 0);
+        for (const { fatal, severity } of result.messages) {
+            if (eslintHelpers.isFatal(fatal, severity)) {
+                result.errorCount++;
+            } else {
+                result.warningCount++;
+            }
         }
     }
 

--- a/lib/report.js
+++ b/lib/report.js
@@ -167,9 +167,12 @@ const convertMythXReport2EsIssue = (report, data) => {
             const sourceIndex = getSourceIndex(location);
             const fileName = sourceList[sourceIndex];
 
-            if (fileName && sources[fileName]) {
+            if (fileName) {
                 sourcePath = fileName;
-                sourceCode = sources[fileName].content;
+
+                if (sources[fileName]) {
+                    sourceCode = sources[fileName].content;
+                }
             }
         }
 

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -74,7 +74,7 @@ describe('Compile test', () => {
                 );
             } else {
                 assert.fail(
-                    "None of compile data or compile error were detected"
+                    'None of compile data or compile error were detected'
                 );
             }
         }).timeout(20000);


### PR DESCRIPTION
## Brief
Latest API response format changes are sometimes causing crashes on output rendering. This PR fixes that.

## Status
**Stable**.

## Changes
- Fixed linting issue in test suite. https://github.com/b-mueller/sabre/blob/ca79c0853b2ac676a2e6592dfa92bde272c4dd76/test/compile.test.js#L77
- Fixed spinner improper behaviour when debug is turned on.
- Added spinner message `Rendering output` to distinct API response receiving errors and output rendering errors, cause less confusion and narrow execution stage that may cause problems in the future. https://github.com/b-mueller/sabre/blob/ca79c0853b2ac676a2e6592dfa92bde272c4dd76/lib/controllers/analyze.js#L174
-  Fixed report rendering to match API changes and properly display issues without references to a file. Unreferenced issues will be assigned to `<unknown>` file with empty code string. https://github.com/b-mueller/sabre/blob/ca79c0853b2ac676a2e6592dfa92bde272c4dd76/lib/report.js#L161-L176
- Optimized execution of counting errors and warnings. https://github.com/b-mueller/sabre/blob/ca79c0853b2ac676a2e6592dfa92bde272c4dd76/lib/report.js#L197-L207

Regards, @blitz-1306.