### PR TITLE
Explicitly state compile errors

### DIFF
--- a/contracts/error.sol
+++ b/contracts/error.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.0;
+
+contract Err {
+    constrictor () public {
+        
+    }
+}

--- a/contracts/no-contracts.sol
+++ b/contracts/no-contracts.sol
@@ -1,0 +1,1 @@
+pragma solidity ^0.5.0;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -155,8 +155,14 @@ const getSolidityVersion = content => {
 
         return solidityVersion;
     } catch (error) {
-        for (let err of error.errors) {
-            console.error(err.message);
+        if (error instanceof parser.ParserError) {
+            const messages = error.errors.map(
+                e => `[line ${e.line}, column ${e.column}] - ${e.message}`
+            );
+
+            throw new Error('Unable to parse input.\n' + messages.join('\n'));
+        } else {
+            throw error;
         }
     }
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const fs = require('fs');
 const axios = require('axios');
 const path = require('path');
@@ -176,7 +175,7 @@ const getSolidityVersion = content => {
  *                   key is a hex string first 4 bytes of keccak256 hash
  *                   and value is a corresponding function signature.
  */
-const getFunctionHashes = (contracts) => {
+const getFunctionHashes = contracts => {
     const hashes = {};
 
     for (const fileName in contracts) {
@@ -198,6 +197,41 @@ const getFunctionHashes = (contracts) => {
     return hashes;
 };
 
+/**
+ * Extract compile errors from Solc compile error/warning messages combined array.
+ * 
+ * @param {string[]|object[]} compileMessages Solc compile messages combined array
+ * 
+ * @returns string[] Array with extracted error message strings
+ */
+const getCompileErrors = compileMessages => {
+    const errors = [];
+
+    for (const compileMessage of compileMessages) {
+        if (compileMessage.severity === 'error') {
+            errors.push(compileMessage.formattedMessage);
+        }
+    }
+
+    return errors;
+};
+
+/**
+ * Safely extract compiled contract bytecode value if there is any.
+ * 
+ * @param {object} contract Solc contract object
+ * 
+ * @returns {string|undefined} Extracted bytecode string or undefined if there is no bytecode.
+ */
+const getByteCodeString = contract => {
+    return (
+        contract &&
+        contract.evm &&
+        contract.evm.bytecode &&
+        contract.evm.bytecode.object
+    );
+};
+
 /*
  * Compile contracts using solc snapshot
  */
@@ -205,21 +239,24 @@ const getFunctionHashes = (contracts) => {
 const getCompiledContracts = (input, solcSnapshot, solidityFileName, compileContractName) => {
     const compiled = JSON.parse(solcSnapshot.compile(JSON.stringify(input)));
 
-    // TODO: Handle the below errors elegantly to be thrown rather than exiting
-    if (!compiled.contracts || !Object.keys(compiled.contracts).length) {
-        if (compiled.errors) {
-            for (const compiledError of compiled.errors) {
-                console.log(chalk.red(compiledError.formattedMessage));
-            }
+    if (compiled.errors) {
+        const errors = getCompileErrors(compiled.errors);
+
+        if (errors.length) {
+            throw new Error('Unable to compile.\n' + errors.join('\n'));
         }
-        process.exit(-1);
+    }
+
+    if (!compiled.contracts || !Object.keys(compiled.contracts).length) {
+        throw new Error('No contracts detected after compiling');
     }
 
     const inputFile = compiled.contracts[solidityFileName];
+
     let contract, contractName;
 
     if (inputFile.length === 0) {
-        throw new Error('✖ No contracts found');
+        throw new Error('No contracts found');
     } else if (inputFile.length === 1) {
         contractName = Object.keys(inputFile)[0];
         contract = inputFile[contractName];
@@ -233,25 +270,34 @@ const getCompiledContracts = (input, solcSnapshot, solidityFileName, compileCont
              * If inheritance is used, the main contract is the largest as it contains the bytecode of all others.
              */
 
-            let bytecodes = {};
+            const byteCodes = {};
 
-            for (let key in inputFile) {
+            for (const key in inputFile) {
                 if (inputFile.hasOwnProperty(key)) {
-                    bytecodes[inputFile[key].evm.bytecode.object.length] = key;
+                    const byteCode = getByteCodeString(inputFile[key]);
+
+                    if (byteCode) {
+                        byteCodes[byteCode.length] = key;
+                    }
                 }
             }
 
-            const largestBytecodeKey = Object.keys(bytecodes).reverse()[0];
+            const largestByteCodeKey = Object.keys(byteCodes).reverse()[0];
 
-            contractName = bytecodes[largestBytecodeKey];
+            contractName = byteCodes[largestByteCodeKey];
             contract = inputFile[contractName];
         }
     }
 
-    /* Bytecode would be empty if contract is only an interface */
+    const byteCode = getByteCodeString(contract);
 
-    if (!contract.evm.bytecode.object) {
-        throw new Error('✖ Compiling the Solidity code did not return any bytecode. Note that abstract contracts cannot be analyzed.');
+    /**
+     * Bytecode would be empty if contract is only an interface.
+     */
+    if (!byteCode) {
+        throw new Error(
+            'Compiling the Solidity code did not return any bytecode. Note that abstract contracts cannot be analyzed.'
+        );
     }
 
     const functionHashes = getFunctionHashes(compiled.contracts);

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -68,10 +68,14 @@ describe('Compile test', () => {
                     )
                 );
             } else if (error) {
-                assert.equal(
-                    error.message,
-                    '✖ Compiling the Solidity code did not return any bytecode. Note that abstract contracts cannot be analyzed.'
-                );
+                const prefixes = [
+                    'Compiling the Solidity code did not return any bytecode',
+                    'Unable to compile',
+                    'No contracts detected after compiling',
+                    'No contracts found'
+                ];
+
+                assert.isTrue(prefixes.some(prefix => error.message.startsWith(prefix)));
             } else {
                 assert.fail(
                     'None of compile data or compile error were detected'


### PR DESCRIPTION
## Brief
Some contracts may have compile errors, however compile errors are stated by `Compiling the Solidity code did not return any bytecode` error message, which sometimes may be misleading. This PR proposes to make compile errors more explicit to end user.

## Status
**Stable**.

## Changes
- Introduced `getCompileErrors()` function to extract only error messages from compiler messages combined array. https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/lib/compiler.js#L200-L217
- Introduced `getByteCodeString()` function to safely extract bytecode from compiled contract data, as previous approach was way too strict, wasn't applied in necessary places and caused problems. https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/lib/compiler.js#L219-L233
- Improved `getCompiledContracts()`:
    - Made compile errors to be explicitly stated: https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/lib/compiler.js#L242-L248
    - Fixed several places where bytecode lookup was triggering errors due to unsafe property access logic:
        - https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/lib/compiler.js#L275-L283
        - https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/lib/compiler.js#L292-L301
- Improved compile test to verify that compile error is whitelisted. https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/test/compile.test.js#L71-L78
- Added test source code samples:
    - Sample containing intentional error to cause compile failure: https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/contracts/error.sol
    - Sample with no contracts at all: https://github.com/b-mueller/sabre/blob/b8339d89ad7c909bfb3793843038c8f8ce87f491/contracts/no-contracts.sol
- Other minor changes.

Regards, @blitz-1306.