### PR TITLE
Submit source code in addition to AST

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 const mythx = require('mythxjs');
 const utils = require('./utils');
 
-const getRequestData = (compiledData, sourceList, fileName, args) => {
+const getRequestData = (input, compiledData, fileName, args) => {
     /* Format data for MythX API */
     const data = {
         contractName: compiledData.contractName,
@@ -9,17 +9,18 @@ const getRequestData = (compiledData, sourceList, fileName, args) => {
         sourceMap: compiledData.contract.evm.deployedBytecode.sourceMap,
         deployedBytecode: utils.replaceLinkedLibs(compiledData.contract.evm.deployedBytecode.object),
         deployedSourceMap: compiledData.contract.evm.deployedBytecode.sourceMap,
-        sourceList,
+        sourceList: Object.keys(input.sources),
         analysisMode: args.mode,
         toolName: args.clientToolName || 'sabre',
         noCacheLookup: args.noCacheLookup,
         sources: {}
     };
 
-    for (let key in compiledData.compiled.sources) {
-        if (compiledData.compiled.sources.hasOwnProperty(key)) {
-            data.sources[key] = { ast: compiledData.compiled.sources[key].ast };
-        }
+    for (const key in compiledData.compiled.sources) {
+        const ast = compiledData.compiled.sources[key].ast;
+        const source = input.sources[key].content;
+
+        data.sources[key] = { ast, source };
     }
 
     data.mainSource = fileName;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -27,25 +27,13 @@ const getSolcInput = sources => {
     };
 };
 
-/* Get solc-js of specific version from temp directory, if exists */
-
-const getImportPaths = source => {
-    let matches = [];
-    let ir = /^(.*import){1}(.+){0,1}\s['"](.+)['"];/gm;
-    let match = null;
-
-    while ((match = ir.exec(source))) {
-        matches.push(match[3]);
-    }
-
-    return matches;
-};
-
 /**
+ * Loads and initializes Solc of supplied version.
  * 
  * @param {string} version Solc version string
  * 
- * @returns {Promise<solc>} Loaded Solc version snapshot object
+ * @returns {object} Loaded Solc version snapshot object
+ *                   and indicator if it was loaded from local cache
  */
 const loadSolcVersion = async version => {
     const tempDir = path.join(path.dirname(require.main.filename), '.temp');
@@ -175,9 +163,9 @@ const getSolidityVersion = content => {
  * as there should be no distinction between their hashes,
  * even if such functions defined in different contracts.
  * 
- * @param {Object} contracts Compiler meta-data about contracts.
+ * @param {object} contracts Compiler meta-data about contracts.
  * 
- * @returns {Object} Dictionary object where
+ * @returns {object} Dictionary object where
  *                   key is a hex string first 4 bytes of keccak256 hash
  *                   and value is a corresponding function signature.
  */
@@ -318,7 +306,6 @@ const getCompiledContracts = (input, solcSnapshot, solidityFileName, compileCont
 
 module.exports = {
     getCompiledContracts,
-    getImportPaths,
     getSolcInput,
     getSolidityVersion,
     loadSolcVersion,

--- a/lib/controllers/analyze.js
+++ b/lib/controllers/analyze.js
@@ -75,26 +75,24 @@ module.exports = async (env, args) => {
 
         spinner.start('Resolving imports');
 
-        /* Parse all the import sources and the `sourceList` */
+        /**
+         * Resolve imported sources and read source code for each file.
+         */
         const resolvedSources = await Profiler.resolveAllSources(
             resolver,
             [solidityFilePath],
             solcSnapshot
         );
 
-        const sourceList = Object.keys(resolvedSources);
-
         spinner.stop();
 
-        spinner.start(
-            sourceList.length === 1 ? 'Compiling source' : 'Compiling sources'
-        );
+        spinner.start('Compiling source(s)');
 
         const allSources = {};
 
-        sourceList.forEach(file => {
+        for (const file in resolvedSources) {
             allSources[file] = { content: resolvedSources[file].body };
-        });
+        }
 
         /* Get the input config for the Solidity Compiler */
         const input = compiler.getSolcInput(allSources);
@@ -119,8 +117,8 @@ module.exports = async (env, args) => {
         spinner.start('Submitting data for analysis');
 
         const data = client.getRequestData(
+            input,
             compiledData,
-            sourceList,
             solidityFilePath,
             args
         );


### PR DESCRIPTION
## Brief
Some vulnerabilities may be detected only with presence of a source code. Currently Sabre is skipping source code submission while API [supports](https://api.mythx.io/v1/openapi#operation/submitAnalysis) input of AST and source code at the same time. This PR proposes to submit code alongside the AST.

## Status
**Stable**.

## Changes
- Implemented sending source code alongside the AST.
    - https://github.com/b-mueller/sabre/blob/cf9516110f4f558b71fa89c88efe141c423084b9/lib/controllers/analyze.js#L119-L124
    - https://github.com/b-mueller/sabre/blob/cf9516110f4f558b71fa89c88efe141c423084b9/lib/client.js#L19-L24
- Removed `compiler.getImportPaths()` as it is not used anywhere.
- Other minor changes.

Regards, @blitz-1306.