### PR TITLE
Fix source location mismatches for bytecode issue locations

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,10 +6,10 @@ const getRequestData = (input, compiledData, fileName, args) => {
     const data = {
         contractName: compiledData.contractName,
         bytecode: utils.replaceLinkedLibs(compiledData.contract.evm.bytecode.object),
-        sourceMap: compiledData.contract.evm.deployedBytecode.sourceMap,
+        sourceMap: compiledData.contract.evm.bytecode.sourceMap,
         deployedBytecode: utils.replaceLinkedLibs(compiledData.contract.evm.deployedBytecode.object),
         deployedSourceMap: compiledData.contract.evm.deployedBytecode.sourceMap,
-        sourceList: Object.keys(input.sources),
+        sourceList: [],
         analysisMode: args.mode,
         toolName: args.clientToolName || 'sabre',
         noCacheLookup: args.noCacheLookup,
@@ -19,6 +19,8 @@ const getRequestData = (input, compiledData, fileName, args) => {
     for (const key in compiledData.compiled.sources) {
         const ast = compiledData.compiled.sources[key].ast;
         const source = input.sources[key].content;
+
+        data.sourceList.push(key);
 
         data.sources[key] = { ast, source };
     }


### PR DESCRIPTION
## Brief
Truffle source resolver sometimes results different source list ordering, so when API response is returned, bytecode locations are sometimes mismatching files. Also, Sabre submits deployment bytecode source map instead of contract bytecode source map, so this results additional confusion and location mismatch.

This PR proposes to fix listed issues.

## Status
**Stable**.

## Changes
- Fixed `client.getRequestData()` to sent proper bytecode source map. https://github.com/b-mueller/sabre/blob/8cd3375ebedb9736ca48e74e486c972d05271ce3/lib/client.js#L8-L9
- Fixed `client.getRequestData()` to set proper order of source file names in `sourceList` - take reliable compiler entries instead of truffle resolver results.
    - https://github.com/b-mueller/sabre/blob/8cd3375ebedb9736ca48e74e486c972d05271ce3/lib/client.js#L12
    - https://github.com/b-mueller/sabre/blob/8cd3375ebedb9736ca48e74e486c972d05271ce3/lib/client.js#L23

Regards, @blitz-1306.