### PR TITLE
Tmp workaround truffle/resolver dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "author": "Bernhard Mueller",
   "license": "MIT",
   "dependencies": {
-    "@truffle/compile-solidity": "^4.2.4",
-    "@truffle/contract": "^4.0.13",
-    "@truffle/resolver": "^6.0.3",
+    "@truffle/compile-solidity": "4.3.15",
+    "@truffle/contract": "4.2.15",
+    "@truffle/resolver": "6.0.11",
     "axios": "^0.19.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^5.16.0",
@@ -34,10 +34,16 @@
     "remix-lib": "^0.4.12",
     "solidity-parser-antlr": "^0.4.11"
   },
+  "resolutions": {
+    "@truffle/compile-common": "0.3.2",
+    "@truffle/resolver": "6.0.11",
+    "@truffle/provisioner": "0.2.0"
+  },
   "bin": {
     "sabre": "./sabre.js"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "lint": "eslint ./sabre.js ./lib ./test",
     "lint:fix": "eslint --fix ./sabre.js ./lib ./test",
     "test": "nyc mocha"


### PR DESCRIPTION
This change resolves the dependency issue until the new version is available.

It's getting an error in runtime because Profiler.resolveAllSources has been moved to compile-common and it's not exported any more in the last release of truffle. Not sure but maybe you can use Profiler.required_sources instead.
