### PR TITLE
move @truffle/compile-solidity from 4.3.15 to 4.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Bernhard Mueller",
   "license": "MIT",
   "dependencies": {
-    "@truffle/compile-solidity": "4.3.15",
+    "@truffle/compile-solidity": "4.3.13",
     "@truffle/contract": "4.2.15",
     "@truffle/resolver": "6.0.11",
     "axios": "^0.19.0",


### PR DESCRIPTION
truffle is moving Profiler from `compile-solidity` to new package `compile-common` since `4.3.14` version, but still not stable and not completed yet.
https://github.com/trufflesuite/truffle/pull/2957
https://github.com/trufflesuite/truffle/pull/3252

so before the migration completed, using version `4.3.13` of `@truffle/compile-solidity` should resolve problem #106.
